### PR TITLE
[fix] Update svtrnet.py

### DIFF
--- a/openrec/modeling/encoders/svtrnet.py
+++ b/openrec/modeling/encoders/svtrnet.py
@@ -236,7 +236,7 @@ class PatchEmbed(nn.Module):
                         stride=2,
                         padding=1,
                         act=nn.GELU,
-                        bias=None,
+                        bias=True,
                     ),
                     ConvBNLayer(
                         in_channels=embed_dim // 2,
@@ -245,7 +245,7 @@ class PatchEmbed(nn.Module):
                         stride=2,
                         padding=1,
                         act=nn.GELU,
-                        bias=None,
+                        bias=True,
                     ),
                 )
             if sub_num == 3:
@@ -257,7 +257,7 @@ class PatchEmbed(nn.Module):
                         stride=2,
                         padding=1,
                         act=nn.GELU,
-                        bias=None,
+                        bias=True,
                     ),
                     ConvBNLayer(
                         in_channels=embed_dim // 4,
@@ -266,7 +266,7 @@ class PatchEmbed(nn.Module):
                         stride=2,
                         padding=1,
                         act=nn.GELU,
-                        bias=None,
+                        bias=True,
                     ),
                     ConvBNLayer(
                         in_channels=embed_dim // 2,
@@ -275,7 +275,7 @@ class PatchEmbed(nn.Module):
                         stride=2,
                         padding=1,
                         act=nn.GELU,
-                        bias=None,
+                        bias=True,
                     ),
                 )
         elif mode == 'linear':


### PR DESCRIPTION
Changed bias parameter from None to True in ConvBNLayer to ensure consistency between Paddle (where bias=None is equivalent to bias=True) and PyTorch (where bias=None is equivalent to bias=False). This avoids unexpected behavior when switching between frameworks.