### PR TITLE
optimize focal loss compute to avoid overflow or underflow

### DIFF
--- a/openrec/losses/ctc_loss.py
+++ b/openrec/losses/ctc_loss.py
@@ -23,9 +23,11 @@ class CTCLoss(nn.Module):
         loss = self.loss_func(predicts, label, preds_lengths, label_length)
 
         if self.use_focal_loss:
-            weight = torch.exp(-loss)
-            weight = 1 - weight
+            # Use torch.clamp to limit the range of loss, avoiding overflow in exponential calculation
+            clamped_loss = torch.clamp(loss, min=-20, max=20)
+            weight = 1 - torch.exp(-clamped_loss)
             weight = torch.square(weight)
-            loss = loss * weight
+            # Use torch.where to avoid multiplying by zero weight
+            loss = torch.where(weight > 0, loss * weight, loss)
         loss = loss.mean()
         return {'loss': loss}


### PR DESCRIPTION
The original focal loss calculation logic is prone to numerical overflow. This PR uses clamp to limit the upper and lower bounds of loss to avoid this problem.