### PR TITLE
[Fix] tools import

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,4 +8,4 @@ __dir__ = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(__dir__)
 sys.path.insert(0, os.path.abspath(os.path.join(__dir__, '..')))
 
-from tools.infer_e2e import OpenOCR, OpenDetector, OpenRecognizer
+from .tools.infer_e2e import OpenOCR, OpenDetector, OpenRecognizer


### PR DESCRIPTION
Fix for https://github.com/Topdu/OpenOCR/issues/54

In version 0.0.6 of openocr-python this causes error on import when not run from inside the OpenOCR repository