### PR TITLE
Performance tuning on the module EncoderWithSVTR.

### DIFF
--- a/openrec/modeling/decoders/ctc_decoder.py
+++ b/openrec/modeling/decoders/ctc_decoder.py
@@ -132,7 +132,7 @@ class EncoderWithSVTR(nn.Module):
         z = self.conv2(z)
         # SVTR global block
         B, C, H, W = z.shape
-        z = z.flatten(2).transpose(1, 2)
+        z = z.flatten(2).transpose(1, 2).contiguous()
         for blk in self.svtr_block:
             z = blk(z)
         z = self.norm(z)


### PR DESCRIPTION
A performance tuning PR to issue #122:
[Performance] issue observed in openrec/modeling/decoders /ctc_decoder.py:EncoderWithSVTR(nn.Module)](https://github.com/Topdu/OpenOCR/issues/122).

Thank you again for open-sourcing and contributing to the community. :)