### PR TITLE
fix: correct overly permissive regex range in label encoders

### DIFF
--- a/openrec/preprocess/ce_label_encode.py
+++ b/openrec/preprocess/ce_label_encode.py
@@ -50,7 +50,7 @@ class BaseRecLabelEncode(object):
         text_re = []
         c_current = ''
         for c in text:
-            if not bool(re.search('[a-zA-Z0-9 :*./%+-١٢٣٤٥٦٧٨٩٠]', c)):
+            if not bool(re.search('[a-zA-Z0-9 :*./%+١٢٣٤٥٦٧٨٩٠-]', c)):
                 if c_current != '':
                     text_re.append(c_current)
                 text_re.append(c)

--- a/openrec/preprocess/ctc_label_encode.py
+++ b/openrec/preprocess/ctc_label_encode.py
@@ -50,7 +50,7 @@ class BaseRecLabelEncode(object):
         text_re = []
         c_current = ''
         for c in text:
-            if not bool(re.search('[a-zA-Z0-9 :*./%+-١٢٣٤٥٦٧٨٩٠]', c)):
+            if not bool(re.search('[a-zA-Z0-9 :*./%+١٢٣٤٥٦٧٨٩٠-]', c)):
                 if c_current != '':
                     text_re.append(c_current)
                 text_re.append(c)


### PR DESCRIPTION
I noticed a small but critical logic issue in the regex patterns used within the label encoders. Specifically, the expression `[...%+-١٢٣٤٥٦٧٨٩٠]` was being interpreted by Python's regex engine as a range between `+` and `١`, which unintentionally covers a wide set of Unicode characters (including symbols like `\`, `[`, `]`, etc.).

By moving the hyphen to the end of the character class, we ensure it's treated as a literal character rather than a range delimiter. This fix improves the accuracy of the label encoding process, especially for datasets involving Arabic numerals and standard mathematical symbols. Checked both `ce_label_encode.py` and `ctc_label_encode.py` to ensure consistency.