### PR TITLE
docs(openocr): fix invalid task name and kwarg syntax in snippets

### DIFF
--- a/docs/openocr.md
+++ b/docs/openocr.md
@@ -83,7 +83,7 @@ Launch Gradio web interface for OCR tasks:
 
 ```bash
 pip install gradio
-openocr --task launch_openoce_demo --server_port 7862 --share
+openocr --task launch_openocr_demo --server_port 7862 --share
 ```
 
 ### Python API Usage
@@ -94,7 +94,7 @@ openocr --task launch_openoce_demo --server_port 7862 --share
 from openocr import OpenOCR
 
 # Initialize OCR engine
-ocr = OpenOCR(mode='mobile', backend=='onnx')
+ocr = OpenOCR(mode='mobile', backend='onnx')
 
 # Process single image
 results, time_dicts = ocr(


### PR DESCRIPTION
Two snippets in docs/openocr.md fail when copy-pasted:

- Local Demo bash block used --task launch_openoce_demo, which is not in the CLI's choices list (see openocr.py and __init__.py). The correct task name, used elsewhere in the docs, is launch_openocr_demo.

- OCR Task Python block used OpenOCR(mode='mobile', backend=='onnx'), which is a SyntaxError (== is a comparison, not a kwarg). Matches the kwarg style already used by the Recognition Task example.

